### PR TITLE
New: Limited support for barriers

### DIFF
--- a/qiskit_rigetti/_qcs_backend.py
+++ b/qiskit_rigetti/_qcs_backend.py
@@ -13,7 +13,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-import warnings
 from typing import Optional, Any, Union, List
 from uuid import uuid4
 
@@ -21,22 +20,11 @@ from pyquil import get_qc
 from pyquil.api import QuantumComputer, EngagementManager
 from qcs_api_client.client import QCSClientConfiguration
 from qiskit import QuantumCircuit, ClassicalRegister
-from qiskit.circuit import Barrier, Measure
+from qiskit.circuit import Measure
 from qiskit.providers import BackendV1, Options, Provider
 from qiskit.providers.models import QasmBackendConfiguration
 
 from ._qcs_job import RigettiQCSJob
-
-
-def _remove_barriers(circuit: QuantumCircuit) -> None:
-    """Strips barriers from the circuit. Mutates the input circuit."""
-    data = []
-    for d in circuit.data:
-        if isinstance(d[0], Barrier):
-            warnings.warn("`barrier` has no effect on a RigettiQCSBackend and will be omitted")
-        else:
-            data.append(d)
-    circuit.data = data
 
 
 def _prepare_readouts(circuit: QuantumCircuit) -> None:
@@ -96,7 +84,6 @@ def _prepare_circuit(circuit: QuantumCircuit) -> QuantumCircuit:
     Returns a prepared copy of the circuit for execution on the QCS Backend.
     """
     circuit = circuit.copy()
-    _remove_barriers(circuit)
     _prepare_readouts(circuit)
     return circuit
 

--- a/qiskit_rigetti/hooks/pre_compilation.py
+++ b/qiskit_rigetti/hooks/pre_compilation.py
@@ -31,6 +31,6 @@ def set_rewiring(rewiring: str) -> PreCompilationHook:
     """
 
     def fn(qasm: str) -> str:
-        return qasm.replace("OPENQASM 2.0;", f'OPENQASM 2.0;\n#pragma INITIAL_REWIRING "{rewiring}"')
+        return qasm.replace("OPENQASM 2.0;", f'OPENQASM 2.0;\n#pragma INITIAL_REWIRING "{rewiring}";')
 
     return fn

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -18,7 +18,7 @@ def test_set_rewiring():
     assert new_qasm.rstrip() == "\n".join(
         [
             "OPENQASM 2.0;",
-            '#pragma INITIAL_REWIRING "NAIVE"',
+            '#pragma INITIAL_REWIRING "NAIVE";',
             'include "qelib1.inc";',
         ]
     )

--- a/tests/test_qcs_backend.py
+++ b/tests/test_qcs_backend.py
@@ -57,25 +57,6 @@ def test_run__multiple_circuits(backend: RigettiQCSBackend):
     assert result.get_counts(1).keys() == {"000"}
 
 
-def test_run__barrier(backend: RigettiQCSBackend):
-    circuit = make_circuit()
-    circuit.barrier()
-    qasm_before = circuit.qasm()
-
-    with pytest.warns(UserWarning, match="`barrier` has no effect on a RigettiQCSBackend and will be omitted"):
-        job = execute(circuit, backend, shots=10)
-
-    assert circuit.qasm() == qasm_before, "should not modify original circuit"
-
-    assert job.backend() is backend
-    result = job.result()
-    assert job.status() == JobStatus.DONE
-    assert result.backend_name == backend.configuration().backend_name
-    assert result.results[0].header.name == circuit.name
-    assert result.results[0].shots == 10
-    assert result.get_counts().keys() == {"00"}
-
-
 def test_run__readout_register_not_named_ro(backend: RigettiQCSBackend):
     circuit = QuantumCircuit(QuantumRegister(2, "q"), ClassicalRegister(2, "not_ro"))
     circuit.measure([0, 1], [0, 1])


### PR DESCRIPTION
For QASM `barrier`s affecting all qubits, replace with an empty Quil `PRESERVE_BLOCK`. Otherwise, omit.

Closes #7 