### PR TITLE
Fix: Backend now binds parametric circuits before execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Removed barrier support until quilc has better compatibility. For now, barriers are omitted during compilation from OpenQASM to Quil, though they will remain in effect for Qiskit's own transpilation/optimization passes (#15)
 
+### Fixes
+
+- Fix errors due to unbound circuits when calling `execute()` with parametric circuits and `parameter_binds` (#16)
+
 
 ## [0.4.1](https://github.com/rigetti/qiskit-rigetti/releases/tag/v0.4.1)
 

--- a/qiskit_rigetti/_qcs_backend.py
+++ b/qiskit_rigetti/_qcs_backend.py
@@ -143,6 +143,10 @@ class RigettiQCSBackend(BackendV1):
         if not isinstance(run_input, list):
             run_input = [run_input]
 
+        bindings = options.get("parameter_binds") or []
+        if len(bindings) > 0:
+            run_input = [circuit.bind_parameters(binding) for circuit in run_input for binding in bindings]
+
         run_input = [_prepare_circuit(circuit) for circuit in run_input]
 
         if self._qc is None:

--- a/tests/test_qcs_backend.py
+++ b/tests/test_qcs_backend.py
@@ -16,6 +16,7 @@
 import pytest
 from qiskit import execute, QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.providers import JobStatus
+from qiskit.circuit import Parameter
 
 from qiskit_rigetti import RigettiQCSProvider, RigettiQCSBackend
 
@@ -55,6 +56,51 @@ def test_run__multiple_circuits(backend: RigettiQCSBackend):
     assert result.results[1].header.name == circuit2.name
     assert result.results[1].shots == 10
     assert result.get_counts(1).keys() == {"000"}
+
+
+def test_run__parametric_circuits(backend: RigettiQCSBackend):
+    t = Parameter("t")
+
+    circuit1 = QuantumCircuit(QuantumRegister(1, "q"), ClassicalRegister(1, "ro"))
+    circuit1.rx(t, 0)
+    circuit1.measure([0], [0])
+
+    circuit2 = QuantumCircuit(QuantumRegister(1, "q"), ClassicalRegister(1, "ro"))
+    circuit2.ry(t, 0)
+    circuit2.measure([0], [0])
+
+    job = execute(
+        [circuit1, circuit2],
+        backend,
+        shots=1000,
+        parameter_binds=[
+            {t: 1.0},
+            {t: 2.0},
+        ],
+    )
+
+    assert job.backend() is backend
+    result = job.result()
+    assert job.status() == JobStatus.DONE
+
+    assert result.backend_name == backend.configuration().backend_name
+    assert len(result.results) == 4
+
+    assert result.results[0].header.name.startswith(f"{circuit1.name}-")
+    assert result.results[0].shots == 1000
+    assert result.get_counts(0).keys() == {"0", "1"}
+
+    assert result.results[1].header.name.startswith(f"{circuit1.name}-")
+    assert result.results[1].shots == 1000
+    assert result.get_counts(1).keys() == {"0", "1"}
+
+    assert result.results[2].header.name.startswith(f"{circuit2.name}-")
+    assert result.results[2].shots == 1000
+    assert result.get_counts(2).keys() == {"0", "1"}
+
+    assert result.results[3].header.name.startswith(f"{circuit2.name}-")
+    assert result.results[3].shots == 1000
+    assert result.get_counts(3).keys() == {"0", "1"}
 
 
 def test_run__readout_register_not_named_ro(backend: RigettiQCSBackend):


### PR DESCRIPTION
NOTE: Merging into `omit-barriers` to release both together

Behavior implemented according to `execute()` docs:

```
parameter_binds (list[dict]): List of Parameter bindings over which the set of
    experiments will be executed. Each list element (bind) should be of the form
    ``{Parameter1: value1, Parameter2: value2, ...}``. All binds will be
    executed across all experiments, e.g. if parameter_binds is a
    length-n list, and there are m experiments, a total of :math:`m x n`
    experiments will be run (one for each experiment/bind pair).
```