### PR TITLE
Fix: Exceptions when executing via QuantumInstance

### DIFF
--- a/qiskit_rigetti/_qcs_provider.py
+++ b/qiskit_rigetti/_qcs_provider.py
@@ -127,4 +127,5 @@ def _configuration(name: str, num_qubits: int, local: bool, simulator: bool) -> 
         memory=False,
         max_shots=10000,
         coupling_map=[],
+        max_experiments=100,
     )

--- a/qiskit_rigetti/_qcs_provider.py
+++ b/qiskit_rigetti/_qcs_provider.py
@@ -127,5 +127,5 @@ def _configuration(name: str, num_qubits: int, local: bool, simulator: bool) -> 
         memory=False,
         max_shots=10000,
         coupling_map=[],
-        max_experiments=100,
+        max_experiments=8,
     )


### PR DESCRIPTION
Fixes #21. There may be more issue as well, so this is a draft until I can pair with @zohimchandani during a reservation to test the fix.

@rigetti/qcs `max_experiments` is how many experiments can be submitted as a single job (basically, how many we'll submit before waiting on all the results). I'm not sure what a good number is here, I don't believe we have any equivalent in pyQuil. Thoughts?