### PR TITLE
Added support for specifying the name of the simulator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-qiskit = "^0.27.0"
+qiskit = "^0.34.0"
 pyquil = "^3.0.0"
 numpy = "^1.20.1"
 importlib_metadata = {version = "*", python = "<3.8"}

--- a/qiskit_rigetti/_qcs_provider.py
+++ b/qiskit_rigetti/_qcs_provider.py
@@ -82,7 +82,7 @@ class RigettiQCSProvider(ProviderV1):
             return self._backends
         return [b for b in self._backends if b.name() == name]
 
-    def get_simulator(self, *, num_qubits: int, noisy: bool = False) -> RigettiQCSBackend:
+    def get_simulator(self, *, name: str = "", num_qubits: int = None, noisy: bool = False) -> RigettiQCSBackend:
         """
         Get a simulator (QVM).
 
@@ -95,7 +95,8 @@ class RigettiQCSProvider(ProviderV1):
         qvm_url = self._client_configuration.profile.applications.pyquil.qvm_url
         local = qvm_url == "" or qvm_url.startswith("http://localhost") or qvm_url.startswith("http://127.0.0.1")
         noisy_str = "-noisy" if noisy else ""
-        name = f"{num_qubits}q{noisy_str}-qvm"
+        if not name:
+            name = f"{num_qubits}q{noisy_str}-qvm"
         configuration = _configuration(name, num_qubits, local=local, simulator=True)
         return RigettiQCSBackend(
             compiler_timeout=self._compiler_timeout,

--- a/scripts/ci_install_deps
+++ b/scripts/ci_install_deps
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+curl -sSL https://install.python-poetry.org | python
 . $HOME/.poetry/env
 poetry --version
 poetry config virtualenvs.in-project true
 poetry run python -m ensurepip --upgrade
+poetry update
 poetry install -vv $1

--- a/tests/test_qcs_backend.py
+++ b/tests/test_qcs_backend.py
@@ -14,11 +14,11 @@
 #    limitations under the License.
 ##############################################################################
 import pytest
-from qiskit import execute, QuantumCircuit, QuantumRegister, ClassicalRegister
-from qiskit.providers import JobStatus
+from qcs_api_client.util.errors import QCSHTTPStatusError
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, execute
 from qiskit.circuit import Parameter
-
-from qiskit_rigetti import RigettiQCSProvider, RigettiQCSBackend
+from qiskit.providers import JobStatus
+from qiskit_rigetti import RigettiQCSBackend, RigettiQCSProvider
 
 
 def test_run(backend: RigettiQCSBackend):
@@ -157,6 +157,22 @@ def test_run__no_measurments(backend: RigettiQCSBackend):
 
     with pytest.raises(RuntimeError, match="Circuit has no measurements"):
         execute(circuit, backend, shots=10)
+
+
+def test_error_is_raised_if_neither_backend_name_or_qubits_specified(monkeypatch):
+    monkeypatch.delenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QVM_URL", raising=False)
+
+    backend = RigettiQCSProvider().get_simulator()
+    with pytest.raises(QCSHTTPStatusError):
+        backend.run(make_circuit(num_qubits=1))
+
+
+def test_error_is_raised_if_backend_simulator_name_doesnt_exist(monkeypatch):
+    monkeypatch.delenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QVM_URL", raising=False)
+
+    backend = RigettiQCSProvider().get_simulator(name="non-existent")
+    with pytest.raises(QCSHTTPStatusError):
+        backend.run(make_circuit(num_qubits=1))
 
 
 @pytest.fixture

--- a/tests/test_qcs_provider.py
+++ b/tests/test_qcs_provider.py
@@ -18,13 +18,22 @@ from pytest_httpx import HTTPXMock
 from qiskit_rigetti import RigettiQCSProvider
 
 
-def test_get_simulator(monkeypatch):
+def test_get_simulator_by_num_qubits(monkeypatch):
     monkeypatch.delenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QVM_URL", raising=False)
 
     backend = RigettiQCSProvider().get_simulator(num_qubits=42)
 
     assert backend.name() == "42q-qvm"
     assert backend.configuration().num_qubits == 42
+    assert backend.configuration().local is True
+    assert backend.configuration().simulator is True
+
+def test_get_simulator_by_name(monkeypatch):
+    monkeypatch.delenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QVM_URL", raising=False)
+
+    backend = RigettiQCSProvider().get_simulator(name="Aspen-11-qvm")
+
+    assert backend.name() == "Aspen-11-qvm"
     assert backend.configuration().local is True
     assert backend.configuration().simulator is True
 


### PR DESCRIPTION
A trivial change which allows the user to give a name directly to the `get_simulator` method rather than purely constructing the name on the number of qubits. This change is useful if you want to run a on `Aspen-11-qvm` for example which is well supported by PyQuil