### PR TITLE
fix: README example needs coupling_map defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ circuit.cx(0, 1)
 circuit.measure([0, 1], [0, 1])
 
 # Execute the circuit on the backend
-job = execute(circuit, backend, shots=10)
+job = execute(circuit, backend, shots=10, coupling_map=backend.coupling_map)
 
 # Grab results from the job
 result = job.result()


### PR DESCRIPTION
Without this change, the following error occurs when using a live backend:

```
qiskit.transpiler.exceptions.TranspilerError: 'Number of qubits greater than device.'
```