### PR TITLE
fix: qiskit version must be < 1.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3167,4 +3167,4 @@ docs = ["furo", "ipython", "myst-parser", "nbsphinx", "sphinx", "sphinx-autoapi"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "d32d995ed2046eb1428bf9acee5eaf28fb305c56696d3b9faf10ea1ba84a9ca1"
+content-hash = "ad70dce22ff11d512c09ac23e62a021280b7e17b81935d8e08e3f1c21fbbd70d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-qiskit = ">=0.38.0"
+qiskit = ">=0.38.0,<1.0.0"
 pyquil = ">=4.0.0,<5.0.0"
 numpy = "^1.23.3"
 importlib_metadata = {version = "*", python = "<3.8"}


### PR DESCRIPTION
The current version of this library is not compatible with qiskit 1.0 or greater, but are dependency specifications weren't reflecting that.